### PR TITLE
修复系统菜单的访问权限授权失败问题

### DIFF
--- a/backend/controllers/MController.php
+++ b/backend/controllers/MController.php
@@ -120,7 +120,7 @@ class MController extends \common\controllers\BaseController
         // 加入模块验证
         if(Yii::$app->controller->module->id != "app-backend")
         {
-            $permissionName = Yii::$app->controller->module->id . '/' . $permissionName;
+            $permissionName = '/' . Yii::$app->controller->module->id . '/' . $permissionName;
         }
 
         // 不需要RBAC判断的路由全称


### PR DESCRIPTION
**问题现象：系统菜单权限授权失败**

操作：将系统菜单中的菜单项权限授权给角色时会出现这个问题。

**第一种情况**：
菜单路由配置: `action-log/index`
$permissionName: `sys/action-log/index`
生成页面链接: `/sys/action-log/index`
结果：401，权限判断不通过，访问失败

**第二种情况**：
菜单路由配置: `sys/action-log/index`
$permissionName: `sys/action-log/index`
生成页面链接: `/sys/sys/action-log/index`
结果：404，要访问的页面不存在，访问失败

涉及代码：

backend/controllers/MController.php:123
backend/modules/sys/views/system/index.php:20


**修复方法：**

方法一：在页面链接生成Url::to()参数前面加斜线/，修补url不准确问题
`<?php echo Url::to(['/'.$v['url']])?>`
效果：
菜单路由配置: `sys/action-log/index`
$permissionName: `sys/action-log/index`
生成页面链接: `/sys/action-log/index`
结果：链接正常，权限正常，能正常访问

方法二：在permissionName生成时最前面加上斜线/，表示为绝对路由
效果：
菜单路由配置: `/sys/action-log/index`
$permissionName: `/sys/action-log/index`
生成页面链接: `/sys/action-log/index`
结果：链接正常，权限正常，能正常访问

**方法一虽然改动小，但这里选择了方法二，因为使用绝对路由更加规范。**
可参考[Yii2作者的发起的讨论](https://github.com/yiisoft/yii2/issues/2724)

**注意**：对于独立module的菜单，需在权限管理中更新，将路由配置为类似`/sys/action-log/index`的形式。

为了降低逐个修改的繁琐操作，可以用我写的下面的语句来完成。
`SELECT url, CONCAT('/', url)FROM sys_menu WHERE url REGEXP  '^[a-z]+/[a-z]+/[a-z]+';`
`UPDATE sys_menu SET url = CONCAT('/', url) WHERE url REGEXP  '^[a-z]+/[a-z]+/[a-z]+';`
`SELECT name, CONCAT('/', name)FROM sys_auth_item WHERE name REGEXP  '^[a-z]+/[a-z]+/[a-z]+';`
`UPDATE sys_auth_item SET name = CONCAT('/', name) WHERE name REGEXP  '^[a-z]+/[a-z]+/[a-z]+';`

数据表sys_auth_item_child有约束，里面的child字段会自动更新
`SELECT child, CONCAT('/', child)FROM sys_auth_item_child WHERE child REGEXP  '^[a-z]+/[a-z]+/[a-z]+';`
